### PR TITLE
fix: remove purple gradient on body to prevent flash on initial load

### DIFF
--- a/Admin/src/index.css
+++ b/Admin/src/index.css
@@ -42,7 +42,7 @@ body {
   margin: 0;
   padding: 0;
   font-family: 'Inter', 'Poppins', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', sans-serif;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: #f8fafc;
   min-height: 100vh;
   color: #1e293b;
   line-height: 1.6;


### PR DESCRIPTION
Changed body background from purple gradient (linear-gradient #667eea to #764ba2) to neutral #f8fafc to eliminate the brief purple flash visible before React mounts.